### PR TITLE
Remove -v flag from curl commands in daily-email.yml

### DIFF
--- a/.github/workflows/daily-email.yml
+++ b/.github/workflows/daily-email.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Trigger Daily Book Email
         run: |
-          echo "Book API response:" && curl -v -X GET https://daily-quote-email.vercel.app/api/daily-book
+          echo "Book API response:" && curl -X GET https://daily-quote-email.vercel.app/api/daily-book
       - name: Trigger Daily Quote Email
         run: |
-          echo "Quote API response:" && curl -v -X GET https://daily-quote-email.vercel.app/api/daily-quote
+          echo "Quote API response:" && curl -X GET https://daily-quote-email.vercel.app/api/daily-quote


### PR DESCRIPTION
This PR removes the -v (verbose) flag from the curl commands in the daily-email.yml workflow file as requested.